### PR TITLE
fix: 웹 스크래핑 도구의 태그 제거 로직 수정

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -58,7 +58,7 @@ def scrape_tool(url: str):
             "svg",
         ]
 
-        for tag in soup.find_all():
+        for tag in soup.find_all(unwanted_tags):
             tag.decompose()
 
         content = soup.get_text(separator=" ")


### PR DESCRIPTION
## 버그 수정

### 문제점
웹 스크래핑 도구에서 불필요한 HTML 태그가 제대로 제거되지 않는 문제가 있었습니다.

### 원인
soup.find_all()에 unwanted_tags 파라미터를 전달하지 않아서 모든 태그를 대상으로 하고 있었습니다.

### 해결책
soup.find_all(unwanted_tags)로 수정하여 unwanted_tags 리스트에 정의된 불필요한 태그들만 정확히 제거하도록 했습니다.

### 개선 효과
- 웹 스크래핑 결과에서 불필요한 HTML 태그가 완전히 제거됨
- 더 깔끔하고 읽기 쉬운 텍스트 추출
- 스크래핑 품질 향상

### 테스트
- 수정된 코드로 웹 스크래핑 테스트 완료
- 불필요한 태그들이 정확히 제거되는지 확인

## 관련 이슈
이 수정사항은 이전 PR의 웹 스크래핑 도구 개선과 관련된 버그 수정입니다.